### PR TITLE
Cli formatter unittests

### DIFF
--- a/test/Formatter/CliFormatterTest.php
+++ b/test/Formatter/CliFormatterTest.php
@@ -14,9 +14,41 @@
 namespace Horde\Log\Formatter\Test;
 use \PHPUnit\Framework\TestCase;
 
+use \Horde_Cli;
 use Horde\Log\Formatter\CliFormatter;
+
+use Horde\Log\LogMessage;
+use Horde\Log\LogLevel;
 
 class CliFormatterTest extends TestCase {
 
+    public function setUp(): void
+    {
+        $this->cli = new Horde_Cli();
+
+        $this->level1 = new LogLevel(1, 'Emergency');
+        $this->level2 = new LogLevel(2, 'warning');
+        $this->level3 = new LogLevel(3, 'info');
+        $this->message1 = "this is an emergency!";
+        $this->message2 = "this is a warning!";
+        $this->message3 = "some info here!";
+        $this->logMessage1 = new LogMessage($this->level1, $this->message1);
+        $this->logMessage2 = new LogMessage($this->level2, $this->message2);
+        $this->logMessage2 = new LogMessage($this->level3, $this->message3);
+
+    }
+
+    public function testDefaultFormat(){
+        $f = new CliFormatter($this->cli);
+        $line = $f->format($this->logMessage1);
+
+        $loglevel = $this->logMessage1->level();
+        $name = $loglevel->name();
+        $criticality = $loglevel->criticality();
+
+        $this->assertStringContainsString($this->message1 , $line);
+        $this->assertStringContainsString($name, $line);
+        $this->assertStringContainsString($criticality, $line);
+    }
 
 }

--- a/test/Formatter/CliFormatterTest.php
+++ b/test/Formatter/CliFormatterTest.php
@@ -29,12 +29,15 @@ class CliFormatterTest extends TestCase {
         $this->level1 = new LogLevel(1, 'Emergency');
         $this->level2 = new LogLevel(2, 'warning');
         $this->level3 = new LogLevel(3, 'info');
+        $this->level4 = new LogLevel(4, 'Some other value');
         $this->message1 = "this is an emergency!";
         $this->message2 = "this is a warning!";
         $this->message3 = "some info here!";
+        $this->message4 = "some other info here!";
         $this->logMessage1 = new LogMessage($this->level1, $this->message1);
         $this->logMessage2 = new LogMessage($this->level2, $this->message2);
         $this->logMessage3 = new LogMessage($this->level3, $this->message3);
+        $this->logMessage4 = new LogMessage($this->level4, $this->message4);
 
     }
 
@@ -56,29 +59,27 @@ class CliFormatterTest extends TestCase {
     public function testColorSettings(){
 
         $f = new CliFormatter($this->cli);
-
-        $logsarray = [$this->logMessage1, $this->logMessage2, $this->logMessage3];
-        // dd($logsarray);
-
+        $logsarray = [$this->logMessage1, $this->logMessage2, $this->logMessage3, $this->logMessage4];
+        
         foreach($logsarray as $key => $value){
-
             $line = $f->format($value);
-
             $loglevel = $value->level();
             $name = $loglevel->name();
+            $logmessage = $value->message();
+            $flag = '['. str_pad($name, 7, ' ', STR_PAD_BOTH) . '] ';
 
             switch ($name) {
                 case 'emergency':
-                    $this->assertStringContainsString("\e[31m", $line);  
+                    $this->assertEquals($this->cli->color('red', $flag) . $logmessage, $line);  
                     break;
                 case 'warning':
-                    $this->assertStringContainsString("\e[33m", $line);  
+                    $this->assertEquals($this->cli->color('yellow', $flag) . $logmessage, $line);  
                     break;
                 case 'info':
-                    $this->assertStringContainsString("\e[34m", $line);  
+                    $this->assertEquals($this->cli->color('blue', $flag) . $logmessage, $line);  
                     break;
                 default:
-                    $this->assertStringContainsString("\e[39m", $line);
+                    $this->assertEquals($flag . $logmessage, $line);
                     break;
             }
         }

--- a/test/Formatter/CliFormatterTest.php
+++ b/test/Formatter/CliFormatterTest.php
@@ -11,17 +11,19 @@
  * @license  http://www.horde.org/licenses/bsd BSD
  * @package  Log
  */
-namespace Horde\Log\Formatter\Test;
-use \PHPUnit\Framework\TestCase;
 
-use \Horde_Cli;
+namespace Horde\Log\Formatter\Test;
+
+use PHPUnit\Framework\TestCase;
+
+use Horde_Cli;
 use Horde\Log\Formatter\CliFormatter;
 
 use Horde\Log\LogMessage;
 use Horde\Log\LogLevel;
 
-class CliFormatterTest extends TestCase {
-
+class CliFormatterTest extends TestCase
+{
     public function setUp(): void
     {
         $this->cli = new Horde_Cli();
@@ -30,19 +32,18 @@ class CliFormatterTest extends TestCase {
         $this->level2 = new LogLevel(2, 'warning');
         $this->level3 = new LogLevel(3, 'info');
         $this->level4 = new LogLevel(4, 'Some other value');
-        $this->message1 = "this is an emergency!";
-        $this->message2 = "this is a warning!";
-        $this->message3 = "some info here!";
-        $this->message4 = "some other info here!";
+        $this->message1 = 'this is an emergency!';
+        $this->message2 = 'this is a warning!';
+        $this->message3 = 'some info here!';
+        $this->message4 = 'some other info here!';
         $this->logMessage1 = new LogMessage($this->level1, $this->message1);
         $this->logMessage2 = new LogMessage($this->level2, $this->message2);
         $this->logMessage3 = new LogMessage($this->level3, $this->message3);
         $this->logMessage4 = new LogMessage($this->level4, $this->message4);
-
     }
 
-    public function testDefaultFormat(){
-
+    public function testDefaultFormat()
+    {
         $f = new CliFormatter($this->cli);
         $line = $f->format($this->logMessage1);
 
@@ -51,17 +52,17 @@ class CliFormatterTest extends TestCase {
 
         # Note: the cliformatter does not output the value of "Criticallity"
         // $criticality = $loglevel->criticality();
-        
-        $this->assertStringContainsString($this->message1 , $line);
-        $this->assertStringContainsString($name, $line);    
+
+        $this->assertStringContainsString($this->message1, $line);
+        $this->assertStringContainsString($name, $line);
     }
 
-    public function testColorSettings(){
-
+    public function testColorSettings()
+    {
         $f = new CliFormatter($this->cli);
         $logsarray = [$this->logMessage1, $this->logMessage2, $this->logMessage3, $this->logMessage4];
-        
-        foreach($logsarray as $key => $value){
+
+        foreach ($logsarray as $key => $value) {
             $line = $f->format($value);
             $loglevel = $value->level();
             $name = $loglevel->name();
@@ -70,23 +71,18 @@ class CliFormatterTest extends TestCase {
 
             switch ($name) {
                 case 'emergency':
-                    $this->assertEquals($this->cli->color('red', $flag) . $logmessage, $line);  
+                    $this->assertEquals($this->cli->color('red', $flag) . $logmessage, $line);
                     break;
                 case 'warning':
-                    $this->assertEquals($this->cli->color('yellow', $flag) . $logmessage, $line);  
+                    $this->assertEquals($this->cli->color('yellow', $flag) . $logmessage, $line);
                     break;
                 case 'info':
-                    $this->assertEquals($this->cli->color('blue', $flag) . $logmessage, $line);  
+                    $this->assertEquals($this->cli->color('blue', $flag) . $logmessage, $line);
                     break;
                 default:
                     $this->assertEquals($flag . $logmessage, $line);
                     break;
             }
         }
-        
-
     }
-
-    
-
 }

--- a/test/Formatter/CliFormatterTest.php
+++ b/test/Formatter/CliFormatterTest.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Horde Log package
+ *
+ * This package is based on Zend_Log from the Zend Framework
+ * (http://framework.zend.com).  Both that package and this
+ * one were written by Mike Naberezny and Chuck Hagenbuch.
+ *
+ * @author   Rafael te Boekhorst <boekhorstb1@b1-systems.de>
+ * @category Horde
+ * @license  http://www.horde.org/licenses/bsd BSD
+ * @package  Log
+ */
+namespace Horde\Log\Formatter\Test;
+use \PHPUnit\Framework\TestCase;
+
+use Horde\Log\Formatter\CliFormatter;
+
+class CliFormatterTest extends TestCase {
+
+
+}

--- a/test/Formatter/CliFormatterTest.php
+++ b/test/Formatter/CliFormatterTest.php
@@ -34,21 +34,52 @@ class CliFormatterTest extends TestCase {
         $this->message3 = "some info here!";
         $this->logMessage1 = new LogMessage($this->level1, $this->message1);
         $this->logMessage2 = new LogMessage($this->level2, $this->message2);
-        $this->logMessage2 = new LogMessage($this->level3, $this->message3);
+        $this->logMessage3 = new LogMessage($this->level3, $this->message3);
 
     }
 
     public function testDefaultFormat(){
+
         $f = new CliFormatter($this->cli);
         $line = $f->format($this->logMessage1);
 
         $loglevel = $this->logMessage1->level();
         $name = $loglevel->name();
-        $criticality = $loglevel->criticality();
 
+        # Note: the cliformatter does not output the value of "Criticallity"
+        // $criticality = $loglevel->criticality();
+        
         $this->assertStringContainsString($this->message1 , $line);
-        $this->assertStringContainsString($name, $line);
-        $this->assertStringContainsString($criticality, $line);
+        $this->assertStringContainsString($name, $line);    
     }
+
+    public function testColorSettings(){
+
+        $f = new CliFormatter($this->cli);
+        $line = $f->format($this->logMessage1);
+
+        $loglevel = $this->logMessage1->level();
+        $name = $loglevel->name();
+
+        switch ($name) {
+            case 'Emergency':
+                $this->assertStringContainsString("\e[31m", $line);  
+                break;
+            case 'warning':
+                $this->assertStringContainsString("\e[33m", $line);  
+                break;
+            case 'info':
+                $this->assertStringContainsString("\e[34m", $line);  
+                break;
+            default:
+                $this->assertStringContainsString("\e[39m", $line);
+                break;
+        }
+
+        
+
+    }
+
+    
 
 }

--- a/test/Formatter/CliFormatterTest.php
+++ b/test/Formatter/CliFormatterTest.php
@@ -56,26 +56,32 @@ class CliFormatterTest extends TestCase {
     public function testColorSettings(){
 
         $f = new CliFormatter($this->cli);
-        $line = $f->format($this->logMessage1);
 
-        $loglevel = $this->logMessage1->level();
-        $name = $loglevel->name();
+        $logsarray = [$this->logMessage1, $this->logMessage2, $this->logMessage3];
+        // dd($logsarray);
 
-        switch ($name) {
-            case 'Emergency':
-                $this->assertStringContainsString("\e[31m", $line);  
-                break;
-            case 'warning':
-                $this->assertStringContainsString("\e[33m", $line);  
-                break;
-            case 'info':
-                $this->assertStringContainsString("\e[34m", $line);  
-                break;
-            default:
-                $this->assertStringContainsString("\e[39m", $line);
-                break;
+        foreach($logsarray as $key => $value){
+
+            $line = $f->format($value);
+
+            $loglevel = $value->level();
+            $name = $loglevel->name();
+
+            switch ($name) {
+                case 'emergency':
+                    $this->assertStringContainsString("\e[31m", $line);  
+                    break;
+                case 'warning':
+                    $this->assertStringContainsString("\e[33m", $line);  
+                    break;
+                case 'info':
+                    $this->assertStringContainsString("\e[34m", $line);  
+                    break;
+                default:
+                    $this->assertStringContainsString("\e[39m", $line);
+                    break;
+            }
         }
-
         
 
     }


### PR DESCRIPTION
- added default test to see if output contains the needed info. Note: criticallity is not in cliformatter outputt
- added a test to check the color codes

Question:
Should I use loops to check for each possible log?