### PR TITLE
Syslog handler test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
             "role": "maintainer"
         }
     ],
-    "time": "2021-12-02",
+    "time": "2021-12-07",
     "repositories": [
         {
             "type": "composer",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,8 @@
          beStrictAboutTodoAnnotatedTests="true"
          failOnRisky="true"
          failOnWarning="true"
-         verbose="true">
+         verbose="true"
+	 colors="true">
     <testsuites>
         <testsuite name="horde/log">
             <directory>test</directory>

--- a/src/Handler/SyslogHandler.php
+++ b/src/Handler/SyslogHandler.php
@@ -87,6 +87,13 @@ class SyslogHandler extends BaseHandler
         $this->lastIdent = $this->options['ident'];
         $this->lastFacility = $this->options['facility'];
 
+        if (!is_string($this->lastIdent)) {
+            throw new LogException('Please set the indent to a String');
+        }
+        if (!is_int($this->options['openlogOptions'])) {
+            throw new LogException('Please set the openlogOptions to a log constant with integer value (e.g. LOG_PERROR). For more information look at PHP documentation about openlog() and its options parameter');
+        }
+
         if (!openlog($this->options['ident'], $this->options['openlogOptions'], $this->options['facility'])) {
             throw new LogException('Unable to open syslog');
         }

--- a/src/Handler/SyslogHandler.php
+++ b/src/Handler/SyslogHandler.php
@@ -93,7 +93,7 @@ class SyslogHandler extends BaseHandler
         if (!is_string($this->lastIdent)) {
             throw new LogException('Please set the indent to a String');
         }
-        if (!is_int($this->options['openlogOptions'])) {
+        if (!is_int($this->options->openLogOptions)) {
             throw new LogException('Please set the openlogOptions to a log constant with integer value (e.g. LOG_PERROR). For more information look at PHP documentation about openlog() and its options parameter');
         }
 

--- a/test/Handler/SyslogHandlerTest.php
+++ b/test/Handler/SyslogHandlerTest.php
@@ -33,9 +33,9 @@ class SyslogHandlerTest extends TestCase
         $this->message1 = 'this is an emergency!';
         $this->logMessage1 = new LogMessage($this->level1, $this->message1, ['timestamp' => date('c')]);
         $this->syshandler = new SyslogHandler();
-        // $this->syslogoptions = new SyslogOptions();
     }
 
+    # Error: Cannot use object of type Horde\Log\Handler\SyslogOptions as array
     public function testWrite()
     {
         $this->assertTrue($this->syshandler->write($this->logMessage1));

--- a/test/Handler/SyslogHandlerTest.php
+++ b/test/Handler/SyslogHandlerTest.php
@@ -36,13 +36,9 @@ class SyslogHandlerTest extends TestCase
 
     public function testWrite(): void
     {
-        // dd($this->logMessage1);
         $this->logMessage1->formatMessage([]);
-
-        $this->syshandler->setOption('ident', 'something');
-        $this->syshandler->setOption('openlogOptions', 1);
-
-
+        $this->syshandler->setOption('ident', 'Where is this log written to? A yes, tot the terminal beacause of "LOG_PERROR" ');
+        $this->syshandler->setOption('openlogOptions', LOG_PERROR);
         $this->assertTrue($this->syshandler->write($this->logMessage1));
     }
 }

--- a/test/Handler/SyslogHandlerTest.php
+++ b/test/Handler/SyslogHandlerTest.php
@@ -38,6 +38,7 @@ class SyslogHandlerTest extends TestCase
     # Error: Cannot use object of type Horde\Log\Handler\SyslogOptions as array
     public function testWrite()
     {
+        $this->logMessage1->formatMessage([]);
         $this->assertTrue($this->syshandler->write($this->logMessage1));
     }
 }

--- a/test/Handler/SyslogHandlerTest.php
+++ b/test/Handler/SyslogHandlerTest.php
@@ -16,6 +16,7 @@
 namespace Horde\Log\Test\Handler;
 
 use Horde\Log\Handler\SyslogHandler;
+use Horde\Log\Handler\SyslogOptions;
 use PHPUnit\Framework\TestCase;
 use Horde\Log\LogHandler;
 use Horde\Log\LogException;
@@ -32,44 +33,11 @@ class SyslogHandlerTest extends TestCase
         $this->message1 = 'this is an emergency!';
         $this->logMessage1 = new LogMessage($this->level1, $this->message1, ['timestamp' => date('c')]);
         $this->syshandler = new SyslogHandler();
+        // $this->syslogoptions = new SyslogOptions();
     }
 
-    # Currently, a log message needs to be formatted beforehand, should this be included in the write() function? Or should an error be thrown here indicating that the message thousl be formatted?
-    public function testIfMessageIsFormatted(): void
+    public function testWrite()
     {
-        $this->expectException('Error');
-        $this->syshandler->setOption('ident', 'Message to terminal" ');
-        $this->syshandler->setOption('openlogOptions', LOG_PERROR);
-        $this->syshandler->write($this->logMessage1);
-    }
-
-    public function testWrite(): void
-    {
-        $this->logMessage1->formatMessage([]);
-        $this->syshandler->setOption('ident', 'Where is this log written to? A yes, tot the terminal beacause of "LOG_PERROR" ');
-        $this->syshandler->setOption('openlogOptions', LOG_PERROR);
         $this->assertTrue($this->syshandler->write($this->logMessage1));
-    }
-
-    public function testIndentErrorInitializeSyslog(): void
-    {
-        $this->expectException(LogException::class);
-        $this->syshandler->setOption('ident', 2);
-        $this->syshandler->setOption('openlogOptions', 1);
-        $this->syshandler->write($this->logMessage1);
-    }
-
-    public function testOptionsErrorInitializeSyslog(): void
-    {
-        $this->expectException(LogException::class);
-        $this->syshandler->setOption('ident', 'some error message');
-        $this->syshandler->setOption('openlogOptions', 'this should be a log constant or at least an integer');
-        $this->syshandler->write($this->logMessage1);
-    }
-
-    # I have not found a way to make the function syslog() within the if-satement of the write()-method... that would be needed to test the errormessages
-    public function testSysLogErrorThrows()
-    {
-        $this->markTestSkipped('should be revisited?');
     }
 }

--- a/test/Handler/SyslogHandlerTest.php
+++ b/test/Handler/SyslogHandlerTest.php
@@ -26,75 +26,23 @@ use Horde\Log\LogLevel;
 class SyslogHandlerTest extends TestCase
 {
     public function setUp(): void
-    { 
+    {
         date_default_timezone_set('America/New_York');
         $this->level1 = new LogLevel(Horde_Log::ALERT, 'Alert');
         $this->message1 = 'this is an emergency!';
         $this->logMessage1 = new LogMessage($this->level1, $this->message1, ['timestamp' => date('c')]);
+        $this->syshandler = new SyslogHandler();
     }
 
-    public function testConstructorThrowsWhenResourceIsNotStream()
+    public function testWrite(): void
     {
-        $this->expectException(LogException::class);
-        new SyslogHandler();
-        xml_parser_free($resource);
+        // dd($this->logMessage1);
+        $this->logMessage1->formatMessage([]);
+
+        $this->syshandler->setOption('ident', 'something');
+        $this->syshandler->setOption('openlogOptions', 1);
+
+
+        $this->assertTrue($this->syshandler->write($this->logMessage1));
     }
-
-    // public function testConstructorWithValidStream()
-    // {
-    //     $stream = fopen('php://memory', 'a');
-    //     $handler = new StreamHandler($stream);
-    //     $this->assertInstanceOf(LogHandler::class, $handler);
-    // }
-
-    // public function testConstructorWithValidUrl()
-    // {
-    //     $handler = new StreamHandler('php://memory');
-    //     $this->assertInstanceOf(LogHandler::class, $handler);
-    // }
-
-    // public function testConstructorThrowsWhenStreamCannotBeOpened()
-    // {
-    //     $this->expectException('Error');
-    //     new StreamHandler('');
-    // }
-
-    // public function testSettingBadOptionThrows()
-    // {
-    //     $this->expectException(LogException::class);
-    //     $handler = new StreamHandler('php://memory');
-    //     $handler->setOption('foo', 42);
-    // }
-
-    // public function testWrite() #See below comment: there is a small issue here
-    // {
-    //     $stream = fopen('php://memory', 'a');
-
-    //     $handler = new StreamHandler($stream);
-    //     $handler->log($this->logMessage1);
-
-    //     rewind($stream);
-    //     $contents = stream_get_contents($stream);
-    //     fclose($stream);
-
-    //     $message = $this->logMessage1->message();
-    //     $levelName = $this->logMessage1->level()->name();
-
-    //     $date = '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}-\d{2}:\d{2}';
-
-    //     $this->assertMatchesRegularExpression("/$date/", $contents);
-    //     $this->assertMatchesRegularExpression("/$message/", $contents);
-    //     // $this->assertMatchesRegularExpression("/$levelName/", $contents); // this does not match levelName, gives an error, because here levelName cannot reach to level->name with the format '%timestamp% %levelName%: %message%' . PHP_EOL... Need to fix default format for SimpleFormatter?
-    // }
-
-    // public function testWriteThrowsWhenStreamWriteFails()
-    // {
-    //     $this->expectException(LogException::class);
-    //     $stream = fopen('php://memory', 'a');
-    //     $handler = new StreamHandler($stream);
-    //     $handler->log($this->logMessage1);
-    //     fclose($stream);
-    //     $handler->write($this->logMessage1);
-    // }
-
 }

--- a/test/Handler/SyslogHandlerTest.php
+++ b/test/Handler/SyslogHandlerTest.php
@@ -16,6 +16,7 @@
 namespace Horde\Log\Test\Handler;
 
 use Horde\Log\Handler\SyslogHandler;
+use Horde\Log\Handler\SyslogOptions;
 use PHPUnit\Framework\TestCase;
 use Horde\Log\LogException;
 use Horde_Log;
@@ -54,6 +55,14 @@ class SyslogHandlerTest extends TestCase
     {
         $this->expectException(LogException::class);
         $this->syshandler->setOption('', '');
+    }
+
+    public function testIfSyslogOptionsAreSet()
+    {
+        $options = new SyslogOptions();
+        $this->assertEquals(LOG_ERR, $options->defaultPriority);
+        $this->assertEquals(LOG_USER, $options->facility);
+        $this->assertEquals(LOG_ODELAY, $options->openLogOptions);
     }
 
 

--- a/test/Handler/SyslogHandlerTest.php
+++ b/test/Handler/SyslogHandlerTest.php
@@ -31,14 +31,21 @@ class SyslogHandlerTest extends TestCase
         $this->level1 = new LogLevel(Horde_Log::ALERT, 'Alert');
         $this->message1 = 'this is an emergency!';
         $this->logMessage1 = new LogMessage($this->level1, $this->message1, ['timestamp' => date('c')]);
-        $this->logMessage1->formatMessage([]);
-
         $this->syshandler = new SyslogHandler();
-        // $this->mock_syshandler = $this->getAccessibleMock(SyslogHandler::class);
+    }
+
+    # Currently, a log message needs to be formatted beforehand, should this be included in the write() function?
+    public function testIfMessageIsFormatted(): void
+    {
+        $this->expectException('Error');
+        $this->syshandler->setOption('ident', 'Message to terminal" ');
+        $this->syshandler->setOption('openlogOptions', LOG_PERROR);
+        $this->syshandler->write($this->logMessage1);
     }
 
     public function testWrite(): void
     {
+        $this->logMessage1->formatMessage([]);
         $this->syshandler->setOption('ident', 'Where is this log written to? A yes, tot the terminal beacause of "LOG_PERROR" ');
         $this->syshandler->setOption('openlogOptions', LOG_PERROR);
         $this->assertTrue($this->syshandler->write($this->logMessage1));

--- a/test/Handler/SyslogHandlerTest.php
+++ b/test/Handler/SyslogHandlerTest.php
@@ -35,14 +35,25 @@ class SyslogHandlerTest extends TestCase
         $this->message1 = 'this is an emergency!';
         $this->logMessage1 = new LogMessage($this->level1, $this->message1, ['timestamp' => date('c')]);
         $this->logMessage1->formatMessage([]);
+        $this->logMessage2 = new LogMessage($this->level1, $this->message1, ['timestamp' => date('c')]);
         $this->syshandler = new SyslogHandler();
     }
 
-    # NB: have to call formatMessage with [] as a formatter. Should this not be done in the code of Sysloghandler.php?
+
     public function testWrite()
     {
         $this->assertTrue($this->syshandler->write($this->logMessage1));
     }
+
+    # NB: have to call formatMessage with [] as a formatter. Should this not be done in the code of Sysloghandler.php?
+    public function testIfMessageIsFormatted(): void
+    {
+        $this->expectException(LogException::class);
+        $this->syshandler->setOption('ident', 'Message to terminal" ');
+        $this->syshandler->setOption('openlogOptions', LOG_PERROR);
+        $this->syshandler->write($this->logMessage2);
+    }
+
 
     public function testIndentErrorInitializeSyslog(): void
     {

--- a/test/Handler/SyslogHandlerTest.php
+++ b/test/Handler/SyslogHandlerTest.php
@@ -34,7 +34,7 @@ class SyslogHandlerTest extends TestCase
         $this->syshandler = new SyslogHandler();
     }
 
-    # Currently, a log message needs to be formatted beforehand, should this be included in the write() function?
+    # Currently, a log message needs to be formatted beforehand, should this be included in the write() function? Or should an error be thrown here indicating that the message thousl be formatted?
     public function testIfMessageIsFormatted(): void
     {
         $this->expectException('Error');
@@ -65,5 +65,11 @@ class SyslogHandlerTest extends TestCase
         $this->syshandler->setOption('ident', 'some error message');
         $this->syshandler->setOption('openlogOptions', 'this should be a log constant or at least an integer');
         $this->syshandler->write($this->logMessage1);
+    }
+
+    # I have not found a way to make the function syslog() within the if-satement of the write()-method... that would be needed to test the errormessages
+    public function testSysLogErrorThrows()
+    {
+        $this->markTestSkipped('should be revisited?');
     }
 }

--- a/test/Handler/SyslogHandlerTest.php
+++ b/test/Handler/SyslogHandlerTest.php
@@ -16,15 +16,11 @@
 namespace Horde\Log\Test\Handler;
 
 use Horde\Log\Handler\SyslogHandler;
-use Horde\Log\Handler\SyslogOptions;
 use PHPUnit\Framework\TestCase;
-use Horde\Log\LogHandler;
 use Horde\Log\LogException;
 use Horde_Log;
 use Horde\Log\LogMessage;
 use Horde\Log\LogLevel;
-
-// use SetOptionsTrait;
 
 class SyslogHandlerTest extends TestCase
 {

--- a/test/Handler/SyslogHandlerTest.php
+++ b/test/Handler/SyslogHandlerTest.php
@@ -24,6 +24,8 @@ use Horde_Log;
 use Horde\Log\LogMessage;
 use Horde\Log\LogLevel;
 
+// use SetOptionsTrait;
+
 class SyslogHandlerTest extends TestCase
 {
     public function setUp(): void
@@ -32,13 +34,35 @@ class SyslogHandlerTest extends TestCase
         $this->level1 = new LogLevel(Horde_Log::ALERT, 'Alert');
         $this->message1 = 'this is an emergency!';
         $this->logMessage1 = new LogMessage($this->level1, $this->message1, ['timestamp' => date('c')]);
+        $this->logMessage1->formatMessage([]);
         $this->syshandler = new SyslogHandler();
     }
 
-    # Error: Cannot use object of type Horde\Log\Handler\SyslogOptions as array
+    # NB: have to call formatMessage with [] as a formatter. Should this not be done in the code of Sysloghandler.php?
     public function testWrite()
     {
-        $this->logMessage1->formatMessage([]);
         $this->assertTrue($this->syshandler->write($this->logMessage1));
+    }
+
+    public function testIndentErrorInitializeSyslog(): void
+    {
+        $this->expectException(LogException::class);
+        $this->syshandler->setOption('ident', 2);
+        $this->syshandler->setOption('openlogOptions', 1);
+        $this->syshandler->write($this->logMessage1);
+    }
+
+    public function testOptionsErrorInitializeSyslog(): void
+    {
+        $this->expectException(LogException::class);
+        $this->syshandler->setOption('ident', 'some error message');
+        $this->syshandler->setOption('openlogOptions', 'this should be a log constant or at least an integer');
+        $this->syshandler->write($this->logMessage1);
+    }
+
+    # I have not found a way to make the function syslog() within the if-satement of the write()-method... that would be needed to test the errormessages
+    public function testSysLogErrorThrows()
+    {
+        $this->markTestSkipped('should be revisited?');
     }
 }

--- a/test/Handler/SyslogHandlerTest.php
+++ b/test/Handler/SyslogHandlerTest.php
@@ -50,6 +50,12 @@ class SyslogHandlerTest extends TestCase
         $this->syshandler->write($this->logMessage2);
     }
 
+    public function testBadOptionKeyThrowsError()
+    {
+        $this->expectException(LogException::class);
+        $this->syshandler->setOption('', '');
+    }
+
 
     public function testIndentErrorInitializeSyslog(): void
     {
@@ -67,7 +73,7 @@ class SyslogHandlerTest extends TestCase
         $this->syshandler->write($this->logMessage1);
     }
 
-    # I have not found a way to make the function syslog() within the if-satement of the write()-method... that would be needed to test the errormessages
+    # I have not found a way to make the function syslog() throw errors (it is located within the if-satement of the write()-method...). That would be needed to test the errormessages
     public function testSysLogErrorThrows()
     {
         $this->markTestSkipped('should be revisited?');

--- a/test/Handler/SyslogHandlerTest.php
+++ b/test/Handler/SyslogHandlerTest.php
@@ -31,14 +31,32 @@ class SyslogHandlerTest extends TestCase
         $this->level1 = new LogLevel(Horde_Log::ALERT, 'Alert');
         $this->message1 = 'this is an emergency!';
         $this->logMessage1 = new LogMessage($this->level1, $this->message1, ['timestamp' => date('c')]);
+        $this->logMessage1->formatMessage([]);
+
         $this->syshandler = new SyslogHandler();
+        // $this->mock_syshandler = $this->getAccessibleMock(SyslogHandler::class);
     }
 
     public function testWrite(): void
     {
-        $this->logMessage1->formatMessage([]);
         $this->syshandler->setOption('ident', 'Where is this log written to? A yes, tot the terminal beacause of "LOG_PERROR" ');
         $this->syshandler->setOption('openlogOptions', LOG_PERROR);
         $this->assertTrue($this->syshandler->write($this->logMessage1));
+    }
+
+    public function testIndentErrorInitializeSyslog(): void
+    {
+        $this->expectException(LogException::class);
+        $this->syshandler->setOption('ident', 2);
+        $this->syshandler->setOption('openlogOptions', 1);
+        $this->syshandler->write($this->logMessage1);
+    }
+
+    public function testOptionsErrorInitializeSyslog(): void
+    {
+        $this->expectException(LogException::class);
+        $this->syshandler->setOption('ident', 'some error message');
+        $this->syshandler->setOption('openlogOptions', 'this should be a log constant or at least an integer');
+        $this->syshandler->write($this->logMessage1);
     }
 }

--- a/test/Handler/SyslogHandlerTest.php
+++ b/test/Handler/SyslogHandlerTest.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Horde Log package
+ *
+ * This package is based on Zend_Log from the Zend Framework
+ * (http://framework.zend.com).  Both that package and this
+ * one were written by Mike Naberezny and Chuck Hagenbuch.
+ *
+ * @author     Rafael te Boekhorst <boekhorstb1@b1-systems.de>
+ * @category   Horde
+ * @license    http://www.horde.org/licenses/bsd BSD
+ * @package    Log
+ * @subpackage UnitTests
+ */
+
+namespace Horde\Log\Test\Handler;
+
+use Horde\Log\Handler\SyslogHandler;
+use PHPUnit\Framework\TestCase;
+use Horde\Log\LogHandler;
+use Horde\Log\LogException;
+use Horde_Log;
+use Horde\Log\LogMessage;
+use Horde\Log\LogLevel;
+
+class SyslogHandlerTest extends TestCase
+{
+    public function setUp(): void
+    { 
+        date_default_timezone_set('America/New_York');
+        $this->level1 = new LogLevel(Horde_Log::ALERT, 'Alert');
+        $this->message1 = 'this is an emergency!';
+        $this->logMessage1 = new LogMessage($this->level1, $this->message1, ['timestamp' => date('c')]);
+    }
+
+    public function testConstructorThrowsWhenResourceIsNotStream()
+    {
+        $this->expectException(LogException::class);
+        new SyslogHandler();
+        xml_parser_free($resource);
+    }
+
+    // public function testConstructorWithValidStream()
+    // {
+    //     $stream = fopen('php://memory', 'a');
+    //     $handler = new StreamHandler($stream);
+    //     $this->assertInstanceOf(LogHandler::class, $handler);
+    // }
+
+    // public function testConstructorWithValidUrl()
+    // {
+    //     $handler = new StreamHandler('php://memory');
+    //     $this->assertInstanceOf(LogHandler::class, $handler);
+    // }
+
+    // public function testConstructorThrowsWhenStreamCannotBeOpened()
+    // {
+    //     $this->expectException('Error');
+    //     new StreamHandler('');
+    // }
+
+    // public function testSettingBadOptionThrows()
+    // {
+    //     $this->expectException(LogException::class);
+    //     $handler = new StreamHandler('php://memory');
+    //     $handler->setOption('foo', 42);
+    // }
+
+    // public function testWrite() #See below comment: there is a small issue here
+    // {
+    //     $stream = fopen('php://memory', 'a');
+
+    //     $handler = new StreamHandler($stream);
+    //     $handler->log($this->logMessage1);
+
+    //     rewind($stream);
+    //     $contents = stream_get_contents($stream);
+    //     fclose($stream);
+
+    //     $message = $this->logMessage1->message();
+    //     $levelName = $this->logMessage1->level()->name();
+
+    //     $date = '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}-\d{2}:\d{2}';
+
+    //     $this->assertMatchesRegularExpression("/$date/", $contents);
+    //     $this->assertMatchesRegularExpression("/$message/", $contents);
+    //     // $this->assertMatchesRegularExpression("/$levelName/", $contents); // this does not match levelName, gives an error, because here levelName cannot reach to level->name with the format '%timestamp% %levelName%: %message%' . PHP_EOL... Need to fix default format for SimpleFormatter?
+    // }
+
+    // public function testWriteThrowsWhenStreamWriteFails()
+    // {
+    //     $this->expectException(LogException::class);
+    //     $stream = fopen('php://memory', 'a');
+    //     $handler = new StreamHandler($stream);
+    //     $handler->log($this->logMessage1);
+    //     fclose($stream);
+    //     $handler->write($this->logMessage1);
+    // }
+
+}


### PR DESCRIPTION
- I adapted SyslogHandler.php to throw errors for php8
- I have not found a way to make the function syslog() within the if-satement of the write()-method... that would be needed to test the errormessages